### PR TITLE
Minor adjustment of the installer related scripts for macOS 12.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Changed
+    
+* Installer related scripts compatible with `macOS 12.3` (@DeployNull)
+
 ## [1.3.0]
 
 ### Added

--- a/Installer/payload/Library/Application Support/SplashBuddy/SplashBuddy.launch.sh
+++ b/Installer/payload/Library/Application Support/SplashBuddy/SplashBuddy.launch.sh
@@ -7,7 +7,7 @@
 # We cannot do it here as LaunchAgent are executed by the user.
 
 
-loggedInUser=$(/usr/bin/python -c 'from SystemConfiguration import SCDynamicStoreCopyConsoleUser; import sys; username = (SCDynamicStoreCopyConsoleUser(None, None, None) or [None])[0]; username = [username,""][username in [u"loginwindow", None, u""]]; sys.stdout.write(username + "\n");')
+loggedInUser=$(/bin/echo "show State:/Users/ConsoleUser" | /usr/sbin/scutil | /usr/bin/awk '/Name :/&&!/loginwindow/{print $3}')
 
 
 app="/Library/Application Support/SplashBuddy/SplashBuddy.app"

--- a/Installer/scripts/postinstall
+++ b/Installer/scripts/postinstall
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-loggedInUser=`python -c 'from SystemConfiguration import SCDynamicStoreCopyConsoleUser; import sys; username = (SCDynamicStoreCopyConsoleUser(None, None, None) or [None])[0]; username = [username,""][username in [u"loginwindow", None, u""]]; sys.stdout.write(username + "\n");'`
+loggedInUser=$(/bin/echo "show State:/Users/ConsoleUser" | /usr/sbin/scutil | /usr/bin/awk '/Name :/&&!/loginwindow/{print $3}')
 loggedInUID=`id -u ${loggedInUser}`
 
 if [[ ${loggedInUID} -gt 500 ]]; then

--- a/Tools/UninstallSplashBuddy.sh
+++ b/Tools/UninstallSplashBuddy.sh
@@ -8,7 +8,7 @@ rm -rf "/Library/Application Support/SplashBuddy"
 rm "/Library/LaunchAgents/io.fti.SplashBuddy.launch.plist"
 rm "/Library/Preferences/io.fti.SplashBuddy.plist"
 
-loggedInUser=$(python -c 'from SystemConfiguration import SCDynamicStoreCopyConsoleUser; import sys; username = (SCDynamicStoreCopyConsoleUser(None, None, None) or [None])[0]; username = [username,""][username in [u"loginwindow", None, u""]]; sys.stdout.write(username + "\n");')
+loggedInUser=$(/bin/echo "show State:/Users/ConsoleUser" | /usr/sbin/scutil | /usr/bin/awk '/Name :/&&!/loginwindow/{print $3}')
 
 rm "/Users/${loggedInUser}/Library/Containers/io.fti.SplashBuddy/Data/Library/.SplashBuddyDone"
 


### PR DESCRIPTION
This approach of getting the current user should be future proof. For additional reading, see @scriptingosx article https://scriptingosx.com/2019/09/get-current-user-in-shell-scripts-on-macos/ 😊